### PR TITLE
Refactor assets

### DIFF
--- a/lib/handlers/asset.post.js
+++ b/lib/handlers/asset.post.js
@@ -65,6 +65,7 @@ const Parser = class Parser extends Duplex {
                 if (error) {
                     // TODO: Handle error
                 }
+                this._done = true;
                 this.emit('done');
             });
         });
@@ -95,11 +96,15 @@ const Parser = class Parser extends Duplex {
     }
 
     _final(cb) {
-        this.once('done', () => {
-            // console.log(JSON.stringify(this.uploadLog, null, 2));
+        if (this._done) {
             this.push(null);
             cb();
-        });
+        } else {
+            this.once('done', () => {
+                this.push(null);
+                cb();
+            });
+        }
     }
 }
 

--- a/test/classes/alias.js
+++ b/test/classes/alias.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Alias = require('../../lib/classes/alias');
 const tap = require('tap');
+const Alias = require('../../lib/classes/alias');
 
 //
 // Constructor

--- a/test/classes/asset.js
+++ b/test/classes/asset.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Asset = require('../../lib/classes/asset');
 const tap = require('tap');
+const Asset = require('../../lib/classes/asset');
 
 //
 // Constructor

--- a/test/classes/http-incoming.js
+++ b/test/classes/http-incoming.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const HttpIncoming = require('../../lib/classes/http-incoming');
 const tap = require('tap');
+const HttpIncoming = require('../../lib/classes/http-incoming');
 
 //
 // Constructor

--- a/test/classes/http-outgoing.js
+++ b/test/classes/http-outgoing.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const HttpOutgoing = require('../../lib/classes/http-outgoing');
 const tap = require('tap');
+const HttpOutgoing = require('../../lib/classes/http-outgoing');
 
 //
 // Constructor

--- a/test/classes/import-map-entry.js
+++ b/test/classes/import-map-entry.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const ImportMapEntry = require('../../lib/classes/import-map-entry');
 const tap = require('tap');
+const ImportMapEntry = require('../../lib/classes/import-map-entry');
 
 //
 // Constructor

--- a/test/classes/import-map.js
+++ b/test/classes/import-map.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const ImportMap = require('../../lib/classes/import-map');
 const tap = require('tap');
+const ImportMap = require('../../lib/classes/import-map');
 
 //
 // Constructor

--- a/test/classes/upload-log.js
+++ b/test/classes/upload-log.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const UploadLog = require('../../lib/classes/upload-log');
 const tap = require('tap');
+const UploadLog = require('../../lib/classes/upload-log');
 
 //
 // Constructor


### PR DESCRIPTION
@trygve-lie can I get your opinion on this? I've added a little extra guarding around the 'done' event emission which I discovered during testing can have already fired before the _final method is called there by hanging the stream forever. This was the first solution that hit me but maybe there is a nicer way to ensure that no matter when the _final method is called, it won't miss the done event?

I've isolated the change to [this commit](https://github.com/asset-pipe/core/pull/4/commits/67e480e692795b1245cf36a35ebc6023c42b9bc6) if you want to avoid looking at the lint fix noise