### PR TITLE
Add .exist() method

### DIFF
--- a/lib/sinks/fs.js
+++ b/lib/sinks/fs.js
@@ -5,6 +5,8 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 
+const DEFAULT_ROOT_PATH = path.join(os.tmpdir(), '/asset-pipe');
+
 /**
  * A sink for persisting files to local file system
  *
@@ -12,12 +14,14 @@ const os = require('os');
  */
 
 class SinkFS {
-    constructor() {
-        this._dir = `${os.tmpdir()}/asset-pipe`;
+    constructor({
+        rootPath = DEFAULT_ROOT_PATH
+    } = {}) {
+        this._rootPath = rootPath;
     }
 
     write(filePath) {
-        const pathname = path.join(this._dir, filePath);
+        const pathname = path.join(this._rootPath, filePath);
         const dir = path.dirname(pathname);
 
         // TODO: make this non blocking without returning a promise from write
@@ -32,7 +36,7 @@ class SinkFS {
     }
 
     read(filePath) {
-        const pathname = path.join(this._dir, filePath);
+        const pathname = path.join(this._rootPath, filePath);
         return fs.createReadStream(pathname, {
             autoClose: true,
             emitClose: true,
@@ -40,11 +44,20 @@ class SinkFS {
     }
 
     delete(filePath) {
-        const pathname = path.join(this._dir, filePath);
+        const pathname = path.join(this._rootPath, filePath);
         const dir = path.dirname(pathname);
 
         return new Promise((resolve, reject) => {
             rimraf(dir, error => {
+                if (error) return reject(error);
+                return resolve();
+            });
+        });
+    }
+
+    exist(filePath) {
+        return new Promise((resolve, reject) => {
+            fs.access(filePath, fs.F_OK, error => {
                 if (error) return reject(error);
                 return resolve();
             });

--- a/lib/sinks/gcs.js
+++ b/lib/sinks/gcs.js
@@ -4,6 +4,7 @@ const { Storage } = require('@google-cloud/storage');
 
 /**
  * A sink for uploading files to Google Cloud Storage
+ * https://googleapis.dev/nodejs/storage/latest/
  *
  * @class SinkGCS
  */
@@ -61,6 +62,16 @@ class SinkGCS {
         const src = this._bucket.file(filePath);
         return new Promise((resolve, reject) => {
             src.delete(error => {
+                if (error) return reject(error);
+                return resolve();
+            });
+        });
+    }
+
+    exist(filePath) {
+        const src = this._bucket.file(filePath);
+        return new Promise((resolve, reject) => {
+            src.exists(error => {
                 if (error) return reject(error);
                 return resolve();
             });


### PR DESCRIPTION
This appends a `.exist()`method to both sinks. We need such methods to check if something exist in the a storage in different routes.