### PR TITLE
Add public entry point for module

### DIFF
--- a/fixtures/sink-test.js
+++ b/fixtures/sink-test.js
@@ -75,7 +75,7 @@ class SinkTest {
                 return reject(new Error(`Directory traversal - ${filePath}`));
             }
 
-            const buff = this._state.get(pathname);
+            const buff = this._state.get(pathname) || [];
             const stream = new Readable({
                 read() {
                     buff.forEach((item) => {

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const aliasPost = require('./handlers/alias.post');
+const aliasPut = require('./handlers/alias.put');
+const aliasGet = require('./handlers/alias.get');
+const aliasDel = require('./handlers/alias.delete');
+const pkgGet = require('./handlers/pkg.get');
+const pkgPut = require('./handlers/pkg.put');
+const mapPut = require('./handlers/map.put');
+const mapGet = require('./handlers/map.get');
+
+const MEM = require('./sinks/mem');
+const GCS = require('./sinks/gcs');
+const FS = require('./sinks/fs');
+
+const globals = require('./utils/globals');
+
+module.exports.http = {
+    aliasPost,
+    aliasPut,
+    aliasGet,
+    aliasDel,
+    pkgGet,
+    pkgPut,
+    mapPut,
+    mapGet,
+};
+
+module.exports.sink = {
+    MEM,
+    GCS,
+    FS,
+};
+
+module.exports.prop = {
+    base_map: globals.BASE_IMPORT_MAPS,
+    base_pkg: globals.BASE_ASSETS,
+};

--- a/lib/sinks/fs.js
+++ b/lib/sinks/fs.js
@@ -44,7 +44,7 @@ class SinkFS {
             });
 
             // TODO: Handle if stream never opens or errors, set a timeout which will reject with an error
-            return;
+            
         });
     }
 
@@ -75,7 +75,7 @@ class SinkFS {
             });
 
             // TODO: Handle if stream never opens or errors, set a timeout which will reject with an error
-            return;
+            
         });
     }
 
@@ -94,7 +94,7 @@ class SinkFS {
             });
 
             // TODO: Handle if stream never opens or errors, set a timeout which will reject with an error
-            return;
+            
         });
     }
 
@@ -113,7 +113,7 @@ class SinkFS {
             });
 
             // TODO: Handle if stream never opens or errors, set a timeout which will reject with an error
-            return;
+            
         });
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "core",
+  "name": "@asset-pipe/core",
   "version": "1.0.0",
   "description": "Core package for Asset Pipe server",
-  "main": "services/fastify.js",
+  "main": "lib/main.js",
   "scripts": {
     "test": "tap test/**/*.js",
     "start": "NODE_DEBUG=foo node services/fastify.js",

--- a/test/integration/fastify.js
+++ b/test/integration/fastify.js
@@ -7,11 +7,11 @@ const { join } = require('path');
 const { createReadStream } = require('fs');
 const extractBody = require('./utils/extract-body');
 const FastifyService = require('../../services/fastify');
-const SinkMem = require('../../lib/sinks/mem');
+const SinkTest = require('../../fixtures/sink-test');
 
 test('Packages GET', async t => {
-    const sink = new SinkMem();
-    const service = new FastifyService({ sink, logger: false });
+    const sink = new SinkTest();
+    const service = new FastifyService({ customSink: sink, logger: false });
     await service.start();
 
     sink.set('/biz/pkg/fuzz/8.4.1/main/index.js', 'hello world');
@@ -27,8 +27,8 @@ test('Packages GET', async t => {
 });
 
 test('Packages PUT - all files extracted, files accessible after upload', async t => {
-    const sink = new SinkMem();
-    const service = new FastifyService({ sink, logger: false });
+    const sink = new SinkTest();
+    const service = new FastifyService({ customSink: sink, logger: false });
     await service.start();
 
     const formData = new FormData();
@@ -83,8 +83,8 @@ test('Packages PUT - all files extracted, files accessible after upload', async 
 });
 
 test('Packages PUT - all files extracted, correct response received', async t => {
-    const sink = new SinkMem();
-    const service = new FastifyService({ sink, logger: false });
+    const sink = new SinkTest();
+    const service = new FastifyService({ customSink: sink, logger: false });
     await service.start();
 
     const formData = new FormData();
@@ -180,8 +180,8 @@ test('Packages PUT - all files extracted, correct response received', async t =>
 });
 
 test('Alias GET', async t => {
-    const sink = new SinkMem();
-    const service = new FastifyService({ sink, logger: false });
+    const sink = new SinkTest();
+    const service = new FastifyService({ customSink: sink, logger: false });
     await service.start();
 
     sink.set(
@@ -208,8 +208,8 @@ test('Alias GET', async t => {
 });
 
 test('Alias DELETE', async t => {
-    const sink = new SinkMem();
-    const service = new FastifyService({ sink, logger: false });
+    const sink = new SinkTest();
+    const service = new FastifyService({ customSink: sink, logger: false });
     await service.start();
 
     sink.set(
@@ -237,8 +237,8 @@ test('Alias DELETE', async t => {
 });
 
 test('Alias PUT', async t => {
-    const sink = new SinkMem();
-    const service = new FastifyService({ sink, logger: false });
+    const sink = new SinkTest();
+    const service = new FastifyService({ customSink: sink, logger: false });
     await service.start();
 
     sink.set('/biz/pkg/fuzz/8.4.1/main/index.js', 'hello world');
@@ -271,8 +271,8 @@ test('Alias PUT', async t => {
 });
 
 test('Alias POST', async t => {
-    const sink = new SinkMem();
-    const service = new FastifyService({ sink, logger: false });
+    const sink = new SinkTest();
+    const service = new FastifyService({ customSink: sink, logger: false });
     await service.start();
 
     sink.set('/biz/pkg/fuzz/8.4.1/main/index.js', 'hello world');
@@ -305,8 +305,8 @@ test('Alias POST', async t => {
 });
 
 test('Map GET', async t => {
-    const sink = new SinkMem();
-    const service = new FastifyService({ sink, logger: false });
+    const sink = new SinkTest();
+    const service = new FastifyService({ customSink: sink, logger: false });
     await service.start();
 
     sink.set(
@@ -335,8 +335,8 @@ test('Map GET', async t => {
 });
 
 test('Map PUT', async t => {
-    const sink = new SinkMem();
-    const service = new FastifyService({ sink, logger: false });
+    const sink = new SinkTest();
+    const service = new FastifyService({ customSink: sink, logger: false });
     await service.start();
 
     const formData = new FormData();


### PR DESCRIPTION
This creates one public entry point for the core module by pulling all handler, sink and public global values into one main file which is exposed with selected properties.

Currently these are exported methods and properties. We might want this to export an constructor instead at one point.