### PR TITLE
Simplify import map put handler

### DIFF
--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -68,7 +68,7 @@ Status codes:
 -   `401` if user is not authorized
 -   `409` if module already exist
 -   `415` if file format of the uploaded file is unsupported
--   `502` if package could not be altered by the sink
+-   `502` if package could not be written to the sink
 
 Example:
 
@@ -138,12 +138,12 @@ Form parameters:
 
 Status codes:
 
--   `201` if import map is successfully uploaded
+-   `303` if import map is successfully uploaded. `location` is [Public Import Map URL](#public-import-map-url)
 -   `400` if validation in URL parameters or form fields fails
 -   `401` if user is not authorized
 -   `409` if import map already exist
 -   `415` if file format of the uploaded import map is unsupported
--   `502` if import map could not be altered by the sink
+-   `502` if import map could not be written to the sink
 
 Example:
 

--- a/examples/map.put.js
+++ b/examples/map.put.js
@@ -4,7 +4,6 @@
 'use strict';
 
 const FormData = require('form-data');
-const { Writable } = require('stream');
 const fetch = require('node-fetch');
 const fs = require('fs');
 
@@ -14,13 +13,10 @@ formData.append('map', fs.createReadStream('../fixtures/import-map.json'));
 fetch('http://localhost:4001/biz/map/buzz/4.2.2', {
     method: 'PUT',
     body: formData,
-}).then(res => {
-    const stream = new Writable({
-        objectMode: false,
-        write(chunk, encoding, callback) {
-            console.log(JSON.parse(chunk.toString()));
-            callback();
-        },
-    });
-    res.body.pipe(stream);
+    headers: formData.getHeaders(),
+})
+.then(res => res.json())
+.then(json => console.log(json))
+.catch((err) => {
+    console.log(err)
 });

--- a/lib/handlers/map.put.js
+++ b/lib/handlers/map.put.js
@@ -1,115 +1,84 @@
 'use strict';
 
-const { pipeline, Duplex } = require('stream');
 const HttpError = require('http-errors');
 const Busboy = require('busboy');
 const HttpIncoming = require('../classes/http-incoming');
 const HttpOutgoing = require('../classes/http-outgoing');
-const ImportMap = require('../classes/import-map');
 const validators = require('../utils/validators');
+const ImportMap = require('../classes/import-map');
+const utils = require('../utils/utils');
 
-const Parser = class Parser extends Duplex {
-    constructor(incoming, sink) {
-        super();
+const parser = (sink, incoming) => {
+    return new Promise((resolve, reject) => {
+        const pathname = ImportMap.buildPathname(
+            incoming.org,
+            incoming.name,
+            incoming.version,
+        );
 
-        this._done = false;
+        const path = ImportMap.buildPath(
+            incoming.org,
+            incoming.name,
+            incoming.version,
+        );
 
-        this.parser = new Busboy({
+        const busboy = new Busboy({
             headers: incoming.headers,
             limits: {
-                fields: 4,
+                fields: 0,
                 files: 1,
-                fileSize: 100000,
+                fileSize: 1000000,
             },
         });
 
-        // eslint-disable-next-line no-unused-vars
-        this.parser.on('field', (name, value) => {});
-
-        this.parser.on(
+        busboy.on(
             'file',
             async (fieldname, file, filename, encoding, mimetype) => {
                 // We accept only one file on this given fieldname.
                 // Throw if any other files is posted.
                 if (fieldname !== 'map') {
-                    this.destroy(new HttpError(400, 'Bad request'));
+                    busboy.destroy(new HttpError(400, 'Bad request'));
                     return;
                 }
 
-                /* TODO: find better way to validate if its a proper import map...
-                if (mimetype !== 'application/json') {
-                    this.destroy(new HttpError(415, 'Unsupported media type'));
+                // Buffer up the incoming file and check if we can
+                // parse it as JSON or not.
+                let obj = {};
+                try {
+                    const str = await utils.streamCollector(file);
+                    obj = JSON.parse(str);
+                } catch (error) {
+                    busboy.destroy(new HttpError(415, 'Unsupported media type'));
                     return;
                 }
-                */
 
-                const path = ImportMap.buildPath(
-                    incoming.org,
-                    incoming.name,
-                    incoming.version,
-                );
-
-                const writer = await sink.write(path, mimetype);
-                pipeline(file, writer, error => {
-                    if (error) {
-                        // Writing the file to the sink failed, terminate the stream
-                        this.destroy(error);
-                        return;
-                    }
-                    this._done = true;
-                    this.emit('done');
-                });
+                // Write file to storage.
+                try {
+                    await utils.writeJSON(sink, path, obj, 'application/json');
+                } catch (error) {
+                    busboy.destroy(new HttpError(502, 'Bad gateway'));
+                }
             },
         );
-    }
 
-    _read() {
-        // Push to readable happens in constructor
-    }
-
-    _write(chunk, enc, cb) {
-        this.parser.write(chunk);
-        cb();
-    }
-
-    _final(cb) {
-        if (this._done) {
-            this.push(null);
-            cb();
-            return;
-        }
-
-        this.once('done', () => {
-            this.push(null);
-            cb();
-        });
-    }
-};
-
-const init = (sink, incoming) => {
-    return new Promise((resolve, reject) => {
-        const parser = new Parser(incoming, sink);
-
-        const outgoing = new HttpOutgoing();
-        outgoing.mimeType = 'application/octet-stream';
-
-        parser.on('done', (/* state */) => {
+        busboy.on('finish', () => {
+            const outgoing = new HttpOutgoing();
+            outgoing.mimeType = 'text/plain';
+            outgoing.statusCode = 302;
+            outgoing.location = pathname;
             resolve(outgoing);
         });
 
-        // If incoming.request is handeled by pipeline, it will close
-        // to early for the http framework to handle it. Let the
-        // http framework handle closing incoming.request
-        incoming.request.pipe(parser);
-
-        pipeline(parser, outgoing, error => {
-            if (error) {
-                reject(error);
-            }
+        busboy.on('error', error => {
+            reject(error);
         });
+
+        // If incoming.request is handeled by stream.pipeline, it will
+        // close to early for the http framework to handle it. Let the
+        // http framework handle closing incoming.request
+        incoming.request.pipe(busboy);
     });
 };
-
 
 const handler = async (sink, req, org, name, version) => {
     try {
@@ -126,7 +95,11 @@ const handler = async (sink, req, org, name, version) => {
         org,
     });
 
-    const stream = await init(sink, incoming);
-    return stream;
+    try {
+        const outgoing = await parser(sink, incoming);
+        return outgoing;
+    } catch(error) {
+        throw error;
+    }
 };
 module.exports.handler = handler;

--- a/lib/handlers/map.put.js
+++ b/lib/handlers/map.put.js
@@ -64,7 +64,7 @@ const parser = (sink, incoming) => {
         busboy.on('finish', () => {
             const outgoing = new HttpOutgoing();
             outgoing.mimeType = 'text/plain';
-            outgoing.statusCode = 302;
+            outgoing.statusCode = 303;
             outgoing.location = pathname;
             resolve(outgoing);
         });

--- a/lib/handlers/map.put.js
+++ b/lib/handlers/map.put.js
@@ -33,7 +33,7 @@ const parser = (sink, incoming) => {
 
         busboy.on(
             'file',
-            async (fieldname, file, filename, encoding, mimetype) => {
+            async (fieldname, file) => {
                 // We accept only one file on this given fieldname.
                 // Throw if any other files is posted.
                 if (fieldname !== 'map') {
@@ -95,11 +95,7 @@ const handler = async (sink, req, org, name, version) => {
         org,
     });
 
-    try {
-        const outgoing = await parser(sink, incoming);
-        return outgoing;
-    } catch(error) {
-        throw error;
-    }
+    const outgoing = await parser(sink, incoming);
+    return outgoing;
 };
 module.exports.handler = handler;

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -53,3 +53,21 @@ const writeJSON = (sink, path, obj, contentType) => {
     });
 };
 module.exports.writeJSON = writeJSON;
+
+const streamCollector = (from) => {
+    return new Promise((resolve, reject) => {
+        const buffer = [];
+        const to = new Writable({
+            write(chunk, encoding, cb) {
+                buffer.push(chunk);
+                cb();
+            },
+        });
+
+        pipeline(from, to, error => {
+            if (error) return reject(error);
+            return resolve(buffer.join().toString());
+        });
+    });
+};
+module.exports.streamCollector = streamCollector;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "tap test/**/*.js",
     "start": "NODE_DEBUG=foo node services/fastify.js",
-    "lint:format": "eslint --fix .",
+    "lint:fix": "eslint --fix .",
     "lint": "eslint ."
   },
   "keywords": [],

--- a/services/fastify.js
+++ b/services/fastify.js
@@ -115,7 +115,8 @@ class FastifyService {
                 );
 
                 reply.type(stream.mimeType);
-                reply.send(stream);
+                reply.code(stream.statusCode);
+                reply.redirect(stream.location);
             },
         );
 

--- a/test/integration/fastify.js
+++ b/test/integration/fastify.js
@@ -310,7 +310,7 @@ test('Map GET', async t => {
     await service.start();
 
     sink.set(
-        '/biz/map/buzz/4.2.2/import-map.json',
+        '/biz/map/buzz/4.2.2.json',
         JSON.stringify({
             imports: {
                 fuzz: 'http://localhost:4001/finn/pkg/fuzz/v8',
@@ -343,6 +343,7 @@ test('Map PUT', async t => {
     formData.append(
         'map',
         createReadStream(join(__dirname, '../../fixtures/import-map.json')),
+        {}
     );
 
     const res = await fetch('http://localhost:4001/biz/map/buzz/4.2.2', {
@@ -351,7 +352,7 @@ test('Map PUT', async t => {
         headers: formData.getHeaders(),
     });
 
-    const content = sink.get('/biz/map/buzz/4.2.2/import-map.json');
+    const content = sink.get('/biz/map/buzz/4.2.2.json');
 
     t.same(
         JSON.parse(content),


### PR DESCRIPTION
This simplifies and hardens the import map put handler.

One notable change is that when a successful upload is done it will respond with a http 303 redirect instead of a 2xx status. The redirect points to the GET URI of the import map. The advantage of this is that the client can follow the redirect and get the uploaded import map from the GET route when its done uploading. When a http cache are in front of the GET route this will populate the http cache with the image map upon upload.