### PR TITLE
Test slow pkg PUT writes

### DIFF
--- a/services/fastify.js
+++ b/services/fastify.js
@@ -295,7 +295,8 @@ class FastifyService {
 
     async start() {
         try {
-            await this.app.listen(this.port);
+            const address = await this.app.listen(this.port);
+            return address;
         } catch (err) {
             this.app.log.error(err);
             throw err;

--- a/test/integration/fastify.js
+++ b/test/integration/fastify.js
@@ -10,13 +10,13 @@ const SinkTest = require('../../fixtures/sink-test');
 
 test('Packages GET', async t => {
     const sink = new SinkTest();
-    const service = new FastifyService({ customSink: sink, logger: false });
-    await service.start();
+    const service = new FastifyService({ customSink: sink, port: 0, logger: false });
+    const address = await service.start();
 
     sink.set('/biz/pkg/fuzz/8.4.1/main/index.js', 'hello world');
 
     const res = await fetch(
-        'http://localhost:4001/biz/pkg/fuzz/8.4.1/main/index.js',
+        `${address}/biz/pkg/fuzz/8.4.1/main/index.js`,
     );
     const body = await res.text();
     t.equals(res.status, 200, 'server should respond with 200 ok');
@@ -27,8 +27,8 @@ test('Packages GET', async t => {
 
 test('Packages PUT - all files extracted, files accessible after upload', async t => {
     const sink = new SinkTest();
-    const service = new FastifyService({ customSink: sink, logger: false });
-    await service.start();
+    const service = new FastifyService({ customSink: sink, logger: false, port: 0 });
+    const address = await service.start();
 
     const formData = new FormData();
     formData.append(
@@ -36,7 +36,7 @@ test('Packages PUT - all files extracted, files accessible after upload', async 
         createReadStream(join(__dirname, '../../fixtures/archive.tgz')),
     );
 
-    const res = await fetch('http://localhost:4001/foo/pkg/bar/1.1.1', {
+    const res = await fetch(`${address}/foo/pkg/bar/1.1.1`, {
         method: 'PUT',
         body: formData,
         headers: formData.getHeaders(),
@@ -45,25 +45,25 @@ test('Packages PUT - all files extracted, files accessible after upload', async 
     t.equals(res.status, 200, 'server PUT should respond with 200 ok');
 
     const file1 = await fetch(
-        'http://localhost:4001/foo/pkg/bar/1.1.1/main/index.js',
+        `${address}/foo/pkg/bar/1.1.1/main/index.js`,
     );
     const file2 = await fetch(
-        'http://localhost:4001/foo/pkg/bar/1.1.1/main/index.js.map',
+        `${address}/foo/pkg/bar/1.1.1/main/index.js.map`
     );
     const file3 = await fetch(
-        'http://localhost:4001/foo/pkg/bar/1.1.1/ie11/index.js',
+        `${address}/foo/pkg/bar/1.1.1/ie11/index.js`,
     );
     const file4 = await fetch(
-        'http://localhost:4001/foo/pkg/bar/1.1.1/ie11/index.js.map',
+        `${address}/foo/pkg/bar/1.1.1/ie11/index.js.map`,
     );
     const file5 = await fetch(
-        'http://localhost:4001/foo/pkg/bar/1.1.1/main/index.css',
+        `${address}/foo/pkg/bar/1.1.1/main/index.css`,
     );
     const file6 = await fetch(
-        'http://localhost:4001/foo/pkg/bar/1.1.1/main/index.css.map',
+        `${address}/foo/pkg/bar/1.1.1/main/index.css.map`,
     );
     const file7 = await fetch(
-        'http://localhost:4001/foo/pkg/bar/1.1.1/assets.json',
+        `${address}/foo/pkg/bar/1.1.1/assets.json`,
     );
 
     t.equals(file1.status, 200, 'GET to index.js responded with 200 ok');
@@ -83,8 +83,8 @@ test('Packages PUT - all files extracted, files accessible after upload', async 
 
 test('Packages PUT - all files extracted, correct response received', async t => {
     const sink = new SinkTest();
-    const service = new FastifyService({ customSink: sink, logger: false });
-    await service.start();
+    const service = new FastifyService({ customSink: sink, port: 0, logger: false });
+    const address = await service.start();
 
     const formData = new FormData();
     formData.append(
@@ -92,7 +92,7 @@ test('Packages PUT - all files extracted, correct response received', async t =>
         createReadStream(join(__dirname, '../../fixtures/archive.tgz')),
     );
 
-    const res = await fetch('http://localhost:4001/biz/pkg/frazz/2.1.4', {
+    const res = await fetch(`${address}/biz/pkg/frazz/2.1.4`, {
         method: 'PUT',
         body: formData,
         headers: formData.getHeaders(),
@@ -180,8 +180,8 @@ test('Packages PUT - all files extracted, correct response received', async t =>
 
 test('Alias GET', async t => {
     const sink = new SinkTest();
-    const service = new FastifyService({ customSink: sink, logger: false });
-    await service.start();
+    const service = new FastifyService({ customSink: sink, port: 0, logger: false });
+    const address = await service.start();
 
     sink.set(
         '/biz/pkg/fuzz/8.alias.json',
@@ -197,7 +197,7 @@ test('Alias GET', async t => {
     sink.set('/biz/pkg/fuzz/8.4.1/main/index.js', 'hello world');
 
     const res = await fetch(
-        'http://localhost:4001/biz/pkg/fuzz/v8/main/index.js',
+        `${address}/biz/pkg/fuzz/v8/main/index.js`,
     );
     const body = await res.text();
     t.equals(res.status, 200, 'server should respond with 200 ok');
@@ -208,8 +208,8 @@ test('Alias GET', async t => {
 
 test('Alias DELETE', async t => {
     const sink = new SinkTest();
-    const service = new FastifyService({ customSink: sink, logger: false });
-    await service.start();
+    const service = new FastifyService({ customSink: sink, port: 0, logger: false });
+    const address = await service.start();
 
     sink.set(
         '/biz/pkg/fuzz/8.alias.json',
@@ -222,7 +222,7 @@ test('Alias DELETE', async t => {
     );
     sink.set('/biz/pkg/fuzz/8.4.1/main/index.js', 'hello world');
 
-    await fetch('http://localhost:4001/biz/pkg/fuzz/v8', {
+    await fetch(`${address}/biz/pkg/fuzz/v8`, {
         method: 'DELETE',
     });
 
@@ -237,15 +237,15 @@ test('Alias DELETE', async t => {
 
 test('Alias PUT', async t => {
     const sink = new SinkTest();
-    const service = new FastifyService({ customSink: sink, logger: false });
-    await service.start();
+    const service = new FastifyService({ customSink: sink, port: 0, logger: false });
+    const address = await service.start();
 
     sink.set('/biz/pkg/fuzz/8.4.1/main/index.js', 'hello world');
 
     const formData = new FormData();
     formData.append('version', '8.4.1');
 
-    await fetch('http://localhost:4001/biz/pkg/fuzz/v8', {
+    await fetch(`${address}/biz/pkg/fuzz/v8`, {
         method: 'PUT',
         body: formData,
         headers: formData.getHeaders(),
@@ -271,15 +271,15 @@ test('Alias PUT', async t => {
 
 test('Alias POST', async t => {
     const sink = new SinkTest();
-    const service = new FastifyService({ customSink: sink, logger: false });
-    await service.start();
+    const service = new FastifyService({ customSink: sink, port: 0, logger: false });
+    const address = await service.start();
 
     sink.set('/biz/pkg/fuzz/8.4.1/main/index.js', 'hello world');
 
     const formData = new FormData();
     formData.append('version', '8.4.1');
 
-    await fetch('http://localhost:4001/biz/pkg/fuzz/v8', {
+    await fetch(`${address}/biz/pkg/fuzz/v8`, {
         method: 'POST',
         body: formData,
         headers: formData.getHeaders(),
@@ -305,19 +305,19 @@ test('Alias POST', async t => {
 
 test('Map GET', async t => {
     const sink = new SinkTest();
-    const service = new FastifyService({ customSink: sink, logger: false });
-    await service.start();
+    const service = new FastifyService({ customSink: sink, port: 0, logger: false });
+    const address = await service.start();
 
     sink.set(
         '/biz/map/buzz/4.2.2.json',
         JSON.stringify({
             imports: {
-                fuzz: 'http://localhost:4001/finn/pkg/fuzz/v8',
+                fuzz: `${address}/finn/pkg/fuzz/v8`,
             },
         }),
     );
 
-    const res = await fetch('http://localhost:4001/biz/map/buzz/4.2.2');
+    const res = await fetch(`${address}/biz/map/buzz/4.2.2`);
 
     const content = await res.text();
 
@@ -325,7 +325,7 @@ test('Map GET', async t => {
     t.same(
         content,
         JSON.stringify({
-            imports: { fuzz: 'http://localhost:4001/finn/pkg/fuzz/v8' },
+            imports: { fuzz: `${address}/finn/pkg/fuzz/v8` },
         }),
         'content should be an import map in JSON format',
     );
@@ -335,8 +335,8 @@ test('Map GET', async t => {
 
 test('Map PUT', async t => {
     const sink = new SinkTest();
-    const service = new FastifyService({ customSink: sink, logger: false });
-    await service.start();
+    const service = new FastifyService({ customSink: sink, port: 0, logger: false });
+    const address = await service.start();
 
     const formData = new FormData();
     formData.append(
@@ -345,7 +345,7 @@ test('Map PUT', async t => {
         {}
     );
 
-    const res = await fetch('http://localhost:4001/biz/map/buzz/4.2.2', {
+    const res = await fetch(`${address}/biz/map/buzz/4.2.2`, {
         method: 'PUT',
         body: formData,
         headers: formData.getHeaders(),

--- a/test/integration/pkg-put-write-Integrity.js
+++ b/test/integration/pkg-put-write-Integrity.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const { createReadStream } = require('fs');
+const FormData = require('form-data');
+const { test } = require('tap');
+const { join } = require('path');
+const fetch = require('node-fetch');
+const FastifyService = require('../../services/fastify');
+const Sink = require('../../fixtures/sink-test');
+
+test('Writing to sink is slow and irregular', async t => {
+    const sink = new Sink();
+
+    // Simulate a slow write process by delaying each chunk written
+    // to the sink with something between 10 and 100 + (buffer count) ms.
+    sink.delayWrite = (count) => {
+        const max = 100 + count;
+        const min = 10;
+        return Math.floor(Math.random() * max) + min;
+    };
+
+    const service = new FastifyService({ customSink: sink, logger: false, port: 0 });
+    const address = await service.start();
+
+    const formData = new FormData();
+    formData.append(
+        'filedata',
+        createReadStream(join(__dirname, '../../fixtures/archive.tgz')),
+    );
+
+    const res = await fetch(`${address}/biz/pkg/frazz/2.1.4`, {
+        method: 'PUT',
+        body: formData,
+        headers: formData.getHeaders(),
+    });
+
+    const obj = await res.json();
+
+    t.equals(obj.files.length, 7, 'Response should have 7 items in "files" Array');
+
+    t.equal(
+        obj.files[0].pathname,
+        '/biz/pkg/frazz/2.1.4/main/index.js',
+        'JavaScript file pathname should match',
+    );
+
+    t.equal(
+        obj.files[0].mimeType,
+        'application/javascript',
+        'JavaScript file mime should match',
+    );
+
+    t.equal(
+        obj.files[1].pathname,
+        '/biz/pkg/frazz/2.1.4/main/index.js.map',
+        'JavaScript file source map pathname should match',
+    );
+    t.equal(
+        obj.files[1].mimeType,
+        'application/json',
+        'JavaScript file source map mime should match',
+    );
+
+    t.equal(
+        obj.files[2].pathname,
+        '/biz/pkg/frazz/2.1.4/ie11/index.js',
+        'ie11 fallback bundle pathname should match',
+    );
+    t.equal(
+        obj.files[2].mimeType,
+        'application/javascript',
+        'ie11 fallback bundle mime should match',
+    );
+
+    t.equal(
+        obj.files[3].pathname,
+        '/biz/pkg/frazz/2.1.4/ie11/index.js.map',
+        'ie11 fallback bundle source map pathname should match',
+    );
+    t.equal(
+        obj.files[3].mimeType,
+        'application/json',
+        'ie11 fallback bundle source map mime should match',
+    );
+
+    t.equal(
+        obj.files[4].pathname,
+        '/biz/pkg/frazz/2.1.4/main/index.css',
+        'css file pathname should match',
+    );
+    t.equal(obj.files[4].mimeType, 'text/css', 'css file mime should match');
+
+    t.equal(
+        obj.files[5].pathname,
+        '/biz/pkg/frazz/2.1.4/main/index.css.map',
+        'css file source map pathname should match',
+    );
+    t.equal(
+        obj.files[5].mimeType,
+        'application/json',
+        'css file source map mime should match',
+    );
+
+    t.equal(
+        obj.files[6].pathname,
+        '/biz/pkg/frazz/2.1.4/assets.json',
+        'assets.json pathname should match',
+    );
+    t.equal(
+        obj.files[6].mimeType,
+        'application/json',
+        'assets.json mime should match',
+    );
+
+    await service.stop();
+});


### PR DESCRIPTION
This ads a test for the package PUT feature where the sink is slow to write. 

Each chunk of a stream written to the sink is slowed down with a random time between 10ms and 100ms making the write process slow and inconsistent. In theory this should make it possible to catch any race conditions or early termination of streams piping into a sink.