### PR TITLE
Turn all handlers into classes

### DIFF
--- a/examples/map.alias.post.js
+++ b/examples/map.alias.post.js
@@ -14,5 +14,21 @@ fetch('http://localhost:4001/biz/map/buzz/v4', {
     body: formData,
     headers: formData.getHeaders(),
 })
-    .then(res => res.json())
-    .then(obj => console.log(obj));
+    .then(res => {
+        let result = {};
+        switch (res.status) {
+            case 200:
+                result = res.json();
+                break;
+            case 404:
+                result = { status: res.status, message: 'Not found' };
+                break;
+            default:
+                result = { status: res.status };
+        }
+        return result;
+    })
+    .then(obj => console.log(obj))
+    .catch(error => {
+        console.log(error);
+    });

--- a/lib/handlers/alias.delete.js
+++ b/lib/handlers/alias.delete.js
@@ -1,29 +1,38 @@
 'use strict';
 
-const HttpError = require('http-errors');
 const { validators } = require('@asset-pipe/common');
+const HttpError = require('http-errors');
+const abslog = require('abslog');
 const HttpOutgoing = require('../classes/http-outgoing');
 const Alias = require('../classes/alias');
 
-const handler = async (sink, req, org, type, name, alias) => {
-    try {
-        validators.alias(alias);
-        validators.name(name);
-        validators.type(type);
-        validators.org(org);
-    } catch (error) {
-        throw new HttpError(400, 'Bad request');
+class AliasDel {
+    constructor(sink, config = {}, logger) {
+        this._config = config;
+        this._sink = sink;
+        this._log = abslog(logger);
     }
 
-    try {
-        const path = Alias.buildPath(org, type, name, alias);
-        await sink.delete(path);
-    } catch (error) {
-        return new HttpError(502, 'Bad gateway');
-    }
+    async handler (req, org, type, name, alias) {
+        try {
+            validators.alias(alias);
+            validators.name(name);
+            validators.type(type);
+            validators.org(org);
+        } catch (error) {
+            throw new HttpError(400, 'Bad request');
+        }
 
-    const outgoing = new HttpOutgoing();
-    outgoing.statusCode = 204;
-    return outgoing;
-};
-module.exports.handler = handler;
+        try {
+            const path = Alias.buildPath(org, type, name, alias);
+            await this._sink.delete(path);
+        } catch (error) {
+            return new HttpError(502, 'Bad gateway');
+        }
+
+        const outgoing = new HttpOutgoing();
+        outgoing.statusCode = 204;
+        return outgoing;
+    }
+}
+module.exports = AliasDel;

--- a/lib/handlers/alias.get.js
+++ b/lib/handlers/alias.get.js
@@ -1,42 +1,51 @@
 'use strict';
 
-const HttpError = require('http-errors');
 const { validators } = require('@asset-pipe/common');
+const HttpError = require('http-errors');
+const abslog = require('abslog');
 const HttpOutgoing = require('../classes/http-outgoing');
 const Alias = require('../classes/alias');
 const utils = require('../utils/utils');
 
-const handler = async (sink, req, org, type, name, alias, extra) => {
-    try {
-        validators.alias(alias);
-        validators.extra(extra);
-        validators.name(name);
-        validators.type(type);
-        validators.org(org);
-    } catch (error) {
-        throw new HttpError(404, 'Not found');
+class AliasGet {
+    constructor(sink, config = {}, logger) {
+        this._config = config;
+        this._sink = sink;
+        this._log = abslog(logger);
     }
 
-    const path = Alias.buildPath(org, type, name, alias);
+    async handler (req, org, type, name, alias, extra) {
+        try {
+            validators.alias(alias);
+            validators.extra(extra);
+            validators.name(name);
+            validators.type(type);
+            validators.org(org);
+        } catch (error) {
+            throw new HttpError(404, 'Not found');
+        }
 
-    try {
-        const obj = await utils.readJSON(sink, path);
-        const location = Alias.buildPathname(
-            obj.org,
-            obj.type,
-            obj.name,
-            obj.version,
-            extra,
-        );
+        const path = Alias.buildPath(org, type, name, alias);
 
-        const outgoing = new HttpOutgoing();
-        outgoing.mimeType = 'application/json';
-        outgoing.statusCode = 303;
-        outgoing.location = location;
+        try {
+            const obj = await utils.readJSON(this._sink, path);
+            const location = Alias.buildPathname(
+                obj.org,
+                obj.type,
+                obj.name,
+                obj.version,
+                extra,
+            );
 
-        return outgoing;
-    } catch (error) {
-        throw new HttpError(404, 'Not found');
+            const outgoing = new HttpOutgoing();
+            outgoing.mimeType = 'application/json';
+            outgoing.statusCode = 303;
+            outgoing.location = location;
+
+            return outgoing;
+        } catch (error) {
+            throw new HttpError(404, 'Not found');
+        }
     }
-};
-module.exports.handler = handler;
+}
+module.exports = AliasGet;

--- a/lib/handlers/alias.post.js
+++ b/lib/handlers/alias.post.js
@@ -1,89 +1,98 @@
 'use strict';
 
+const { validators } = require('@asset-pipe/common');
 const HttpError = require('http-errors');
 const Busboy = require('busboy');
-const { validators } = require('@asset-pipe/common');
+const abslog = require('abslog');
 const HttpIncoming = require('../classes/http-incoming');
 const HttpOutgoing = require('../classes/http-outgoing');
 const Alias = require('../classes/alias');
 const utils = require('../utils/utils');
 
-const parser = (sink, incoming) => {
-    return new Promise((resolve, reject) => {
-        const alias = new Alias(incoming);
+class AliasPost {
+    constructor(sink, config = {}, logger) {
+        this._config = config;
+        this._sink = sink;
+        this._log = abslog(logger);
+    }
 
-        const busboy = new Busboy({
-            headers: incoming.headers,
-            limits: {
-                fields: 1,
-                files: 0,
-                fileSize: 0,
-            },
-        });
+    _parser(incoming) {
+        return new Promise((resolve, reject) => {
+            const alias = new Alias(incoming);
 
-        busboy.on('field', (name, value) => {
-            if (name === 'version') {
+            const busboy = new Busboy({
+                headers: incoming.headers,
+                limits: {
+                    fields: 1,
+                    files: 0,
+                    fileSize: 0,
+                },
+            });
+
+            busboy.on('field', (name, value) => {
+                if (name === 'version') {
+                    try {
+                        validators.version(value);
+                    } catch (error) {
+                        busboy.destroy(new HttpError(502, 'Bad gateway'));
+                        return;
+                    }
+                    alias.version = value;
+                }
+            });
+
+            busboy.on('finish', async () => {
                 try {
-                    validators.version(value);
+                    await utils.writeJSON(
+                        this._sink,
+                        alias.path,
+                        alias,
+                        'application/json',
+                    );
                 } catch (error) {
+                    // TODO: Will this trigger error or is it too late to do this in the finish event??????????
                     busboy.destroy(new HttpError(502, 'Bad gateway'));
                     return;
                 }
-                alias.version = value;
-            }
+
+                const outgoing = new HttpOutgoing();
+                outgoing.mimeType = 'text/plain';
+                outgoing.statusCode = 303;
+                outgoing.location = alias.pathname;
+
+                resolve(outgoing);
+            });
+
+            busboy.on('error', error => {
+                reject(error);
+            });
+
+            // If incoming.request is handeled by stream.pipeline, it will
+            // close to early for the http framework to handle it. Let the
+            // http framework handle closing incoming.request
+            incoming.request.pipe(busboy);
         });
-
-        busboy.on('finish', async () => {
-            try {
-                await utils.writeJSON(
-                    sink,
-                    alias.path,
-                    alias,
-                    'application/json',
-                );
-            } catch (error) {
-                // TODO: Will this trigger error or is it too late to do this in the finish event??????????
-                busboy.destroy(new HttpError(502, 'Bad gateway'));
-                return;
-            }
-
-            const outgoing = new HttpOutgoing();
-            outgoing.mimeType = 'text/plain';
-            outgoing.statusCode = 303;
-            outgoing.location = alias.pathname;
-
-            resolve(outgoing);
-        });
-
-        busboy.on('error', error => {
-            reject(error);
-        });
-
-        // If incoming.request is handeled by stream.pipeline, it will
-        // close to early for the http framework to handle it. Let the
-        // http framework handle closing incoming.request
-        incoming.request.pipe(busboy);
-    });
-};
-
-const handler = async (sink, req, org, type, name, alias) => {
-    try {
-        validators.alias(alias);
-        validators.name(name);
-        validators.type(type);
-        validators.org(org);
-    } catch (error) {
-        throw new HttpError(400, 'Bad request');
     }
 
-    const incoming = new HttpIncoming(req, {
-        alias,
-        name,
-        type,
-        org,
-    });
+    async handler (req, org, type, name, alias) {
+        try {
+            validators.alias(alias);
+            validators.name(name);
+            validators.type(type);
+            validators.org(org);
+        } catch (error) {
+            throw new HttpError(400, 'Bad request');
+        }
 
-    const outgoing = await parser(sink, incoming);
-    return outgoing;
-};
-module.exports.handler = handler;
+        const incoming = new HttpIncoming(req, {
+            alias,
+            name,
+            type,
+            org,
+        });
+
+        const outgoing = await this._parser(incoming);
+        return outgoing;
+    }
+}
+module.exports = AliasPost;

--- a/lib/handlers/alias.put.js
+++ b/lib/handlers/alias.put.js
@@ -1,89 +1,98 @@
 'use strict';
 
+const { validators } = require('@asset-pipe/common');
 const HttpError = require('http-errors');
 const Busboy = require('busboy');
-const { validators } = require('@asset-pipe/common');
+const abslog = require('abslog');
 const HttpIncoming = require('../classes/http-incoming');
 const HttpOutgoing = require('../classes/http-outgoing');
 const Alias = require('../classes/alias');
 const utils = require('../utils/utils');
 
-const parser = (sink, incoming) => {
-    return new Promise((resolve, reject) => {
-        const alias = new Alias(incoming);
+class AliasPut {
+    constructor(sink, config = {}, logger) {
+        this._config = config;
+        this._sink = sink;
+        this._log = abslog(logger);
+    }
 
-        const busboy = new Busboy({
-            headers: incoming.headers,
-            limits: {
-                fields: 1,
-                files: 0,
-                fileSize: 0,
-            },
-        });
+    _parser(incoming) {
+        return new Promise((resolve, reject) => {
+            const alias = new Alias(incoming);
 
-        busboy.on('field', (name, value) => {
-            if (name === 'version') {
+            const busboy = new Busboy({
+                headers: incoming.headers,
+                limits: {
+                    fields: 1,
+                    files: 0,
+                    fileSize: 0,
+                },
+            });
+
+            busboy.on('field', (name, value) => {
+                if (name === 'version') {
+                    try {
+                        validators.version(value);
+                    } catch (error) {
+                        busboy.destroy(new HttpError(502, 'Bad gateway'));
+                        return;
+                    }
+                    alias.version = value;
+                }
+            });
+
+            busboy.on('finish', async () => {
                 try {
-                    validators.version(value);
+                    await utils.writeJSON(
+                        this._sink,
+                        alias.path,
+                        alias,
+                        'application/json',
+                    );
                 } catch (error) {
+                    // TODO: Will this trigger error or is it too late to do this in the finish event??????????
                     busboy.destroy(new HttpError(502, 'Bad gateway'));
                     return;
                 }
-                alias.version = value;
-            }
+
+                const outgoing = new HttpOutgoing();
+                outgoing.mimeType = 'text/plain';
+                outgoing.statusCode = 303;
+                outgoing.location = alias.pathname;
+
+                resolve(outgoing);
+            });
+
+            busboy.on('error', error => {
+                reject(error);
+            });
+
+            // If incoming.request is handeled by stream.pipeline, it will
+            // close to early for the http framework to handle it. Let the
+            // http framework handle closing incoming.request
+            incoming.request.pipe(busboy);
         });
-
-        busboy.on('finish', async () => {
-            try {
-                await utils.writeJSON(
-                    sink,
-                    alias.path,
-                    alias,
-                    'application/json',
-                );
-            } catch (error) {
-                // TODO: Will this trigger error or is it too late to do this in the finish event??????????
-                busboy.destroy(new HttpError(502, 'Bad gateway'));
-                return;
-            }
-
-            const outgoing = new HttpOutgoing();
-            outgoing.mimeType = 'text/plain';
-            outgoing.statusCode = 303;
-            outgoing.location = alias.pathname;
-
-            resolve(outgoing);
-        });
-
-        busboy.on('error', error => {
-            reject(error);
-        });
-
-        // If incoming.request is handeled by stream.pipeline, it will
-        // close to early for the http framework to handle it. Let the
-        // http framework handle closing incoming.request
-        incoming.request.pipe(busboy);
-    });
-};
-
-const handler = async (sink, req, org, type, name, alias) => {
-    try {
-        validators.alias(alias);
-        validators.name(name);
-        validators.type(type);
-        validators.org(org);
-    } catch (error) {
-        throw new HttpError(400, 'Bad request');
     }
 
-    const incoming = new HttpIncoming(req, {
-        alias,
-        name,
-        type,
-        org,
-    });
+    async handler (req, org, type, name, alias) {
+        try {
+            validators.alias(alias);
+            validators.name(name);
+            validators.type(type);
+            validators.org(org);
+        } catch (error) {
+            throw new HttpError(400, 'Bad request');
+        }
 
-    const outgoing = await parser(sink, incoming);
-    return outgoing;
-};
-module.exports.handler = handler;
+        const incoming = new HttpIncoming(req, {
+            alias,
+            name,
+            type,
+            org,
+        });
+
+        const outgoing = await this._parser(incoming);
+        return outgoing;
+    }
+}
+module.exports = AliasPut;

--- a/lib/handlers/map.get.js
+++ b/lib/handlers/map.get.js
@@ -1,31 +1,40 @@
 'use strict';
 
-const HttpError = require('http-errors');
 const { validators } = require('@asset-pipe/common');
+const HttpError = require('http-errors');
+const abslog = require('abslog');
 const HttpOutgoing = require('../classes/http-outgoing');
 const ImportMap = require('../classes/import-map');
 
-const handler = async (sink, req, org, name, version) => {
-    try {
-        validators.version(version);
-        validators.name(name);
-        validators.org(org);
-    } catch (error) {
-        throw new HttpError(404, 'Not found');
+class MapGet {
+    constructor(sink, config = {}, logger) {
+        this._config = config;
+        this._sink = sink;
+        this._log = abslog(logger);
     }
 
-    const path = ImportMap.buildPath(org, name, version);
+    async handler (req, org, name, version) {
+        try {
+            validators.version(version);
+            validators.name(name);
+            validators.org(org);
+        } catch (error) {
+            throw new HttpError(404, 'Not found');
+        }
 
-    try {
-        const outgoing = new HttpOutgoing();
-        outgoing.mimeType = 'application/json';
+        const path = ImportMap.buildPath(org, name, version);
 
-        const stream = await sink.read(path);
-        outgoing.stream = stream;
+        try {
+            const outgoing = new HttpOutgoing();
+            outgoing.mimeType = 'application/json';
 
-        return outgoing;
-    } catch (error) {
-        throw new HttpError(404, 'Not found');
+            const stream = await this._sink.read(path);
+            outgoing.stream = stream;
+
+            return outgoing;
+        } catch (error) {
+            throw new HttpError(404, 'Not found');
+        }
     }
-};
-module.exports.handler = handler;
+}
+module.exports = MapGet;

--- a/lib/handlers/map.put.js
+++ b/lib/handlers/map.put.js
@@ -1,98 +1,107 @@
 'use strict';
 
+const { validators } = require('@asset-pipe/common');
 const HttpError = require('http-errors');
 const Busboy = require('busboy');
-const { validators } = require('@asset-pipe/common');
+const abslog = require('abslog');
 const HttpIncoming = require('../classes/http-incoming');
 const HttpOutgoing = require('../classes/http-outgoing');
 const ImportMap = require('../classes/import-map');
 const utils = require('../utils/utils');
 
-const parser = (sink, incoming) => {
-    return new Promise((resolve, reject) => {
-        const pathname = ImportMap.buildPathname(
-            incoming.org,
-            incoming.name,
-            incoming.version,
-        );
-
-        const path = ImportMap.buildPath(
-            incoming.org,
-            incoming.name,
-            incoming.version,
-        );
-
-        const busboy = new Busboy({
-            headers: incoming.headers,
-            limits: {
-                fields: 0,
-                files: 1,
-                fileSize: 1000000,
-            },
-        });
-
-        busboy.on('file', async (fieldname, file) => {
-            // We accept only one file on this given fieldname.
-            // Throw if any other files is posted.
-            if (fieldname !== 'map') {
-                busboy.destroy(new HttpError(400, 'Bad request'));
-                return;
-            }
-
-            // Buffer up the incoming file and check if we can
-            // parse it as JSON or not.
-            let obj = {};
-            try {
-                const str = await utils.streamCollector(file);
-                obj = JSON.parse(str);
-            } catch (error) {
-                busboy.destroy(new HttpError(415, 'Unsupported media type'));
-                return;
-            }
-
-            // Write file to storage.
-            try {
-                await utils.writeJSON(sink, path, obj, 'application/json');
-            } catch (error) {
-                busboy.destroy(new HttpError(502, 'Bad gateway'));
-            }
-        });
-
-        busboy.on('finish', () => {
-            const outgoing = new HttpOutgoing();
-            outgoing.mimeType = 'text/plain';
-            outgoing.statusCode = 303;
-            outgoing.location = pathname;
-            resolve(outgoing);
-        });
-
-        busboy.on('error', error => {
-            reject(error);
-        });
-
-        // If incoming.request is handeled by stream.pipeline, it will
-        // close to early for the http framework to handle it. Let the
-        // http framework handle closing incoming.request
-        incoming.request.pipe(busboy);
-    });
-};
-
-const handler = async (sink, req, org, name, version) => {
-    try {
-        validators.version(version);
-        validators.name(name);
-        validators.org(org);
-    } catch (error) {
-        throw new HttpError(400, 'Bad request');
+class MapPut {
+    constructor(sink, config = {}, logger) {
+        this._config = config;
+        this._sink = sink;
+        this._log = abslog(logger);
     }
 
-    const incoming = new HttpIncoming(req, {
-        version,
-        name,
-        org,
-    });
+    _parser(incoming) {
+        return new Promise((resolve, reject) => {
+            const pathname = ImportMap.buildPathname(
+                incoming.org,
+                incoming.name,
+                incoming.version,
+            );
 
-    const outgoing = await parser(sink, incoming);
-    return outgoing;
-};
-module.exports.handler = handler;
+            const path = ImportMap.buildPath(
+                incoming.org,
+                incoming.name,
+                incoming.version,
+            );
+
+            const busboy = new Busboy({
+                headers: incoming.headers,
+                limits: {
+                    fields: 0,
+                    files: 1,
+                    fileSize: 1000000,
+                },
+            });
+
+            busboy.on('file', async (fieldname, file) => {
+                // We accept only one file on this given fieldname.
+                // Throw if any other files is posted.
+                if (fieldname !== 'map') {
+                    busboy.destroy(new HttpError(400, 'Bad request'));
+                    return;
+                }
+
+                // Buffer up the incoming file and check if we can
+                // parse it as JSON or not.
+                let obj = {};
+                try {
+                    const str = await utils.streamCollector(file);
+                    obj = JSON.parse(str);
+                } catch (error) {
+                    busboy.destroy(new HttpError(415, 'Unsupported media type'));
+                    return;
+                }
+
+                // Write file to storage.
+                try {
+                    await utils.writeJSON(this._sink, path, obj, 'application/json');
+                } catch (error) {
+                    busboy.destroy(new HttpError(502, 'Bad gateway'));
+                }
+            });
+
+            busboy.on('finish', () => {
+                const outgoing = new HttpOutgoing();
+                outgoing.mimeType = 'text/plain';
+                outgoing.statusCode = 303;
+                outgoing.location = pathname;
+                resolve(outgoing);
+            });
+
+            busboy.on('error', error => {
+                reject(error);
+            });
+
+            // If incoming.request is handeled by stream.pipeline, it will
+            // close to early for the http framework to handle it. Let the
+            // http framework handle closing incoming.request
+            incoming.request.pipe(busboy);
+        });
+    }
+
+    async handler (req, org, name, version) {
+        try {
+            validators.version(version);
+            validators.name(name);
+            validators.org(org);
+        } catch (error) {
+            throw new HttpError(400, 'Bad request');
+        }
+
+        const incoming = new HttpIncoming(req, {
+            version,
+            name,
+            org,
+        });
+
+        const outgoing = await this._parser(incoming);
+        return outgoing;
+    }
+}
+module.exports = MapPut;

--- a/lib/handlers/pkg.get.js
+++ b/lib/handlers/pkg.get.js
@@ -1,37 +1,46 @@
 'use strict';
 
-const HttpError = require('http-errors');
 const { validators } = require('@asset-pipe/common');
+const HttpError = require('http-errors');
+const abslog = require('abslog');
 const HttpOutgoing = require('../classes/http-outgoing');
 const Asset = require('../classes/asset');
 
-const handler = async (sink, req, org, name, version, extra) => {
-    try {
-        validators.version(version);
-        validators.extra(extra);
-        validators.name(name);
-        validators.org(org);
-    } catch (error) {
-        throw new HttpError(404, 'Not found');
+class PkgGet {
+    constructor(sink, config = {}, logger) {
+        this._config = config;
+        this._sink = sink;
+        this._log = abslog(logger);
     }
 
-    const asset = new Asset({
-        version,
-        extra,
-        name,
-        org,
-    });
+    async handler (req, org, name, version, extra) {
+        try {
+            validators.version(version);
+            validators.extra(extra);
+            validators.name(name);
+            validators.org(org);
+        } catch (error) {
+            throw new HttpError(404, 'Not found');
+        }
 
-    try {
-        const outgoing = new HttpOutgoing();
-        outgoing.mimeType = asset.mimeType;
+        const asset = new Asset({
+            version,
+            extra,
+            name,
+            org,
+        });
 
-        const stream = await sink.read(asset.path);
-        outgoing.stream = stream;
+        try {
+            const outgoing = new HttpOutgoing();
+            outgoing.mimeType = asset.mimeType;
 
-        return outgoing;
-    } catch (error) {
-        throw new HttpError(404, 'Not found');
+            const stream = await this._sink.read(asset.path);
+            outgoing.stream = stream;
+
+            return outgoing;
+        } catch (error) {
+            throw new HttpError(404, 'Not found');
+        }
     }
-};
-module.exports.handler = handler;
+}
+module.exports = PkgGet;

--- a/lib/handlers/pkg.put.js
+++ b/lib/handlers/pkg.put.js
@@ -2,6 +2,7 @@
 
 const { validators } = require('@asset-pipe/common');
 const { pipeline } = require('stream');
+const abslog = require('abslog');
 const HttpError = require('http-errors');
 const Busboy = require('busboy');
 const tar = require('tar');
@@ -13,136 +14,144 @@ const Asset = require('../classes/asset');
 const Meta = require('../classes/meta');
 const utils = require('../utils/utils');
 
-const parser = (sink, incoming) => {
-    return new Promise((resolve, reject) => {
-        const resolver = [];
+class PkgPut {
+    constructor(sink, config = {}, logger) {
+        this._config = config;
+        this._sink = sink;
+        this._log = abslog(logger);
+    }
 
-        const busboy = new Busboy({
-            headers: incoming.headers,
-            limits: {
-                fields: 4,
-                files: 1,
-                fileSize: 100000000,
-                // fileSize: 100000
-                // fileSize: 1000
-            },
-        });
+    _parser(incoming) {
+        return new Promise((resolve, reject) => {
+            const resolver = [];
 
-        busboy.on('field', (name, value) => {
-            const promise = Promise.resolve(new Meta({ name, value }));
-            resolver.push(promise);
-        });
-
-        busboy.on('file', (fieldname, file) => {
-            // We accept only one file on this given fieldname.
-            // Throw if any other files is posted.
-            if (fieldname !== 'filedata') {
-                busboy.destroy(new HttpError(400, 'Bad request'));
-                return;
-            }
-
-            const extract = new tar.Parse({
-                onentry: (entry) => {
-                    const asset = new Asset({
-                        version: incoming.version,
-                        extra: entry.path,
-                        name: incoming.name,
-                        type: entry.type,
-                        org: incoming.org,
-                    });
-
-                    asset.size = entry.size;
-
-                    if (asset.type !== 'file') {
-                        // Entries not supported must be thrown
-                        // away for extraction to continue
-                        entry.resume();
-                        return;
-                    }
-
-                    // eslint-disable-next-line no-async-promise-executor
-                    const promise = new Promise(async (res, rej) => {
-                        const writer = await sink.write(asset.path, asset.mimeType);
-                        pipeline(entry, writer, error => {
-                            if (error) {
-                                rej(error);
-                                return;
-                            }
-                            res(asset);
-                        });
-                    });
-
-                    resolver.push(promise);
+            const busboy = new Busboy({
+                headers: incoming.headers,
+                limits: {
+                    fields: 4,
+                    files: 1,
+                    fileSize: 100000000,
+                    // fileSize: 100000
+                    // fileSize: 1000
                 },
             });
 
-            pipeline(file, extract, error => {
-                if (error) {
-                    busboy.destroy(new HttpError(415, 'Unsupported media type'));
+            busboy.on('field', (name, value) => {
+                const promise = Promise.resolve(new Meta({ name, value }));
+                resolver.push(promise);
+            });
+
+            busboy.on('file', (fieldname, file) => {
+                // We accept only one file on this given fieldname.
+                // Throw if any other files is posted.
+                if (fieldname !== 'filedata') {
+                    busboy.destroy(new HttpError(400, 'Bad request'));
                     return;
                 }
-                busboy.emit('completed');
-            });
-        });
 
-        busboy.on('error', error => {
-            reject(error);
-        });
+                const extract = new tar.Parse({
+                    onentry: (entry) => {
+                        const asset = new Asset({
+                            version: incoming.version,
+                            extra: entry.path,
+                            name: incoming.name,
+                            type: entry.type,
+                            org: incoming.org,
+                        });
 
-        busboy.once('completed', () => {
-            Promise.all(resolver).then(assets => {
-                const log = new UploadLog(incoming);
-                assets.forEach(obj => {
-                    if (obj instanceof Asset) {
-                        log.setAsset(obj);
+                        asset.size = entry.size;
+
+                        if (asset.type !== 'file') {
+                            // Entries not supported must be thrown
+                            // away for extraction to continue
+                            entry.resume();
+                            return;
+                        }
+
+                        // eslint-disable-next-line no-async-promise-executor
+                        const promise = new Promise(async (res, rej) => {
+                            const writer = await this._sink.write(asset.path, asset.mimeType);
+                            pipeline(entry, writer, error => {
+                                if (error) {
+                                    rej(error);
+                                    return;
+                                }
+                                res(asset);
+                            });
+                        });
+
+                        resolver.push(promise);
+                    },
+                });
+
+                pipeline(file, extract, error => {
+                    if (error) {
+                        busboy.destroy(new HttpError(415, 'Unsupported media type'));
+                        return;
                     }
-                    if (obj instanceof Meta) {
-                        log.setMeta(obj);
-                    }
-                })
-                return log;
-            }).then(async (log) => {
-                await utils.writeJSON(
-                    sink,
-                    log.path,
-                    log,
-                    'application/json',
-                );
-                return log;
-            }).then((log) => {
-                const outgoing = new HttpOutgoing();
-                outgoing.mimeType = 'application/json';
-                outgoing.statusCode = 200;
-                outgoing.body = log;
-                resolve(outgoing);
-            }).catch(err => {
-                reject(err);
+                    busboy.emit('completed');
+                });
             });
+
+            busboy.on('error', error => {
+                reject(error);
+            });
+
+            busboy.once('completed', () => {
+                Promise.all(resolver).then(assets => {
+                    const log = new UploadLog(incoming);
+                    assets.forEach(obj => {
+                        if (obj instanceof Asset) {
+                            log.setAsset(obj);
+                        }
+                        if (obj instanceof Meta) {
+                            log.setMeta(obj);
+                        }
+                    })
+                    return log;
+                }).then(async (log) => {
+                    await utils.writeJSON(
+                        this._sink,
+                        log.path,
+                        log,
+                        'application/json',
+                    );
+                    return log;
+                }).then((log) => {
+                    const outgoing = new HttpOutgoing();
+                    outgoing.mimeType = 'application/json';
+                    outgoing.statusCode = 200;
+                    outgoing.body = log;
+                    resolve(outgoing);
+                }).catch(err => {
+                    reject(err);
+                });
+            });
+
+            // If incoming.request is handeled by pipeline, it will close
+            // to early for the http framework to handle it. Let the
+            // http framework handle closing incoming.request
+            incoming.request.pipe(busboy);
         });
-
-        // If incoming.request is handeled by pipeline, it will close
-        // to early for the http framework to handle it. Let the
-        // http framework handle closing incoming.request
-        incoming.request.pipe(busboy);
-    });
-};
-
-const handler = async (sink, req, org, name, version) => {
-    try {
-        validators.version(version);
-        validators.name(name);
-        validators.org(org);
-    } catch (error) {
-        throw new HttpError(400, 'Bad request');
     }
 
-    const incoming = new HttpIncoming(req, {
-        version,
-        name,
-        org,
-    });
+    async handler (req, org, name, version) {
+        try {
+            validators.version(version);
+            validators.name(name);
+            validators.org(org);
+        } catch (error) {
+            throw new HttpError(400, 'Bad request');
+        }
 
-    const outgoing = await parser(sink, incoming);
-    return outgoing;
-};
-module.exports.handler = handler;
+        const incoming = new HttpIncoming(req, {
+            version,
+            name,
+            org,
+        });
+
+        const outgoing = await this._parser(incoming);
+        return outgoing;
+    }
+}
+module.exports = PkgPut;

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const aliasPost = require('./handlers/alias.post');
-const aliasPut = require('./handlers/alias.put');
-const aliasGet = require('./handlers/alias.get');
-const aliasDel = require('./handlers/alias.delete');
-const pkgGet = require('./handlers/pkg.get');
-const pkgPut = require('./handlers/pkg.put');
-const mapPut = require('./handlers/map.put');
-const mapGet = require('./handlers/map.get');
+const AliasPost = require('./handlers/alias.post');
+const AliasPut = require('./handlers/alias.put');
+const AliasGet = require('./handlers/alias.get');
+const AliasDel = require('./handlers/alias.delete');
+const PkgGet = require('./handlers/pkg.get');
+const PkgPut = require('./handlers/pkg.put');
+const MapGet = require('./handlers/map.get');
+const MapPut = require('./handlers/map.put');
 
 const MEM = require('./sinks/mem');
 const GCS = require('./sinks/gcs');
@@ -16,14 +16,14 @@ const FS = require('./sinks/fs');
 const globals = require('./utils/globals');
 
 module.exports.http = {
-    aliasPost,
-    aliasPut,
-    aliasGet,
-    aliasDel,
-    pkgGet,
-    pkgPut,
-    mapPut,
-    mapGet,
+    AliasPost,
+    AliasPut,
+    AliasGet,
+    AliasDel,
+    PkgGet,
+    PkgPut,
+    MapGet,
+    MapPut,
 };
 
 module.exports.sink = {


### PR DESCRIPTION
This turns all handlers into classes where the constructor takes a sink, a config object and a logger.

The `main` export of this module does now export all the classes so its possible to pull in one file and get holds of all classes like so:

```js
const { http } = require('core');
const app = require('express')();

const aliasPost = new http.AliasPost(sink, {}, logger);
const aliasDel = new http.AliasDel(sink, {}, logger);
const aliasGet = new http.AliasGet(sink, {}, logger);
const aliasPut = new http.AliasPut(sink, {}, logger);
const pkgGet = new http.PkgGet(sink, {}, logger);
const pkgPut = new http.PkgPut(sink, {}, logger);
const mapGet = new http.MapGet(sink, {}, logger);
const mapPut = new http.MapPut(sink, {}, logger);

app.get('/.....', (req, res) => {
    const outgoing = mapGet.handler([... snip ...]);
});
```

This makes sense when using this in a long running http server where the server exposes all http routes.

Though; it is now also possible to get hold of one and one handler which is deal for clout functions:

```js
const { MapGet } = require('core/handlers/mapGet');

const mapGet = new MapGet(sink, {}, logger);

module.export = ('/.....', (req, res) => {
    const outgoing = mapGet.handler([... snip ...]);
});
```

This way we end up with not including dependencies and code not being used in a cloud function. Ex, a function only intended to do `GET` requests do not need to load the body parser dependency which are only used in handlers dealing with `PUT` and `POST`.
