### PR TITLE
Check if aliases exist on all methods which alter an alias

### DIFF
--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -219,7 +219,7 @@ Form parameters:
 
 Status codes:
 
--   `201` if alias is successfully created
+-   `303` if alias is successfully created. `location` points to the alias
 -   `400` if validation in URL parameters or form fields fails
 -   `401` if user is not authorized
 -   `409` if alias already exist
@@ -255,8 +255,7 @@ Form parameters:
 
 Status codes:
 
--   `204` if alias is successfully updated
--   `400` if validation in URL parameters or form fields fails
+-   `303` if alias is successfully created. `location` points to the alias
 -   `401` if user is not authorized
 -   `404` if alias does not exist
 -   `502` if alias could not be altered by the sink
@@ -288,7 +287,6 @@ URL parameters:
 Status codes:
 
 -   `204` if alias is successfully deleted
--   `400` if validation in URL parameters or form fields fails
 -   `401` if user is not authorized
 -   `404` if alias does not exist
 -   `502` if alias could not be altered by the sink

--- a/examples/map.alias.delete.js
+++ b/examples/map.alias.delete.js
@@ -8,5 +8,27 @@ const fetch = require('node-fetch');
 fetch('http://localhost:4001/biz/map/buzz/v4', {
     method: 'DELETE',
 })
-    .then(res => res.text())
-    .then(body => console.log('Alias deleted', body));
+.then(res => {
+    let result = {};
+    switch (res.status) {
+        case 204:
+            result = { status: res.status, message: 'Deleted' };
+            break;
+        case 401:
+            result = { status: res.status, message: 'Unauthorized' };
+            break;
+        case 404:
+            result = { status: res.status, message: 'Not found' };
+            break;
+        case 502:
+            result = { status: res.status, message: 'Writing file failed' };
+            break;
+        default:
+            result = { status: res.status };
+    }
+    return result;
+})
+.then(obj => console.log(obj))
+.catch(error => {
+    console.log(error);
+});

--- a/examples/map.alias.post.js
+++ b/examples/map.alias.post.js
@@ -14,21 +14,27 @@ fetch('http://localhost:4001/biz/map/buzz/v4', {
     body: formData,
     headers: formData.getHeaders(),
 })
-    .then(res => {
-        let result = {};
-        switch (res.status) {
-            case 200:
-                result = res.json();
-                break;
-            case 404:
-                result = { status: res.status, message: 'Not found' };
-                break;
-            default:
-                result = { status: res.status };
-        }
-        return result;
-    })
-    .then(obj => console.log(obj))
-    .catch(error => {
-        console.log(error);
-    });
+.then(res => {
+    let result = {};
+    switch (res.status) {
+        case 200:
+            result = res.json();
+            break;
+        case 401:
+            result = { status: res.status, message: 'Unauthorized' };
+            break;
+        case 404:
+            result = { status: res.status, message: 'Not found' };
+            break;
+        case 502:
+            result = { status: res.status, message: 'Writing file failed' };
+            break;
+        default:
+            result = { status: res.status };
+    }
+    return result;
+})
+.then(obj => console.log(obj))
+.catch(error => {
+    console.log(error);
+});

--- a/examples/map.alias.put.js
+++ b/examples/map.alias.put.js
@@ -14,5 +14,33 @@ fetch('http://localhost:4001/biz/map/buzz/v4', {
     body: formData,
     headers: formData.getHeaders(),
 })
-    .then(res => res.json())
-    .then(obj => console.log(obj));
+.then(res => {
+    let result = {};
+    switch (res.status) {
+        case 200:
+            result = res.json();
+            break;
+        case 400:
+            result = { status: res.status, message: 'Invalid URL parameter' };
+            break;
+        case 401:
+            result = { status: res.status, message: 'Unauthorized' };
+            break;
+        case 409:
+            result = { status: res.status, message: 'Alias exist' };
+            break;
+        case 415:
+            result = { status: res.status, message: 'Unsupported file format' };
+            break;
+        case 502:
+            result = { status: res.status, message: 'Writing file failed' };
+            break;
+        default:
+            result = { status: res.status };
+    }
+    return result;
+})
+.then(obj => console.log(obj))
+.catch(error => {
+    console.log(error);
+});

--- a/examples/pkg.alias.delete.js
+++ b/examples/pkg.alias.delete.js
@@ -8,5 +8,27 @@ const fetch = require('node-fetch');
 fetch('http://localhost:4001/biz/pkg/fuzz/v8', {
     method: 'DELETE',
 })
-    .then(res => res.text())
-    .then(body => console.log('Alias deleted', body));
+.then(res => {
+    let result = {};
+    switch (res.status) {
+        case 204:
+            result = { status: res.status, message: 'Deleted' };
+            break;
+        case 401:
+            result = { status: res.status, message: 'Unauthorized' };
+            break;
+        case 404:
+            result = { status: res.status, message: 'Not found' };
+            break;
+        case 502:
+            result = { status: res.status, message: 'Writing file failed' };
+            break;
+        default:
+            result = { status: res.status };
+    }
+    return result;
+})
+.then(obj => console.log(obj))
+.catch(error => {
+    console.log(error);
+});

--- a/examples/pkg.alias.post.js
+++ b/examples/pkg.alias.post.js
@@ -14,5 +14,27 @@ fetch('http://localhost:4001/biz/pkg/fuzz/v8', {
     body: formData,
     headers: formData.getHeaders(),
 })
-    .then(res => res.json())
-    .then(obj => console.log(obj));
+.then(res => {
+    let result = {};
+    switch (res.status) {
+        case 200:
+            result = res.json();
+            break;
+        case 401:
+            result = { status: res.status, message: 'Unauthorized' };
+            break;
+        case 404:
+            result = { status: res.status, message: 'Not found' };
+            break;
+        case 502:
+            result = { status: res.status, message: 'Writing file failed' };
+            break;
+        default:
+            result = { status: res.status };
+    }
+    return result;
+})
+.then(obj => console.log(obj))
+.catch(error => {
+    console.log(error);
+});

--- a/examples/pkg.alias.put.js
+++ b/examples/pkg.alias.put.js
@@ -14,5 +14,33 @@ fetch('http://localhost:4001/biz/pkg/fuzz/v8', {
     body: formData,
     headers: formData.getHeaders(),
 })
-    .then(res => res.json())
-    .then(obj => console.log(obj));
+.then(res => {
+    let result = {};
+    switch (res.status) {
+        case 200:
+            result = res.json();
+            break;
+        case 400:
+            result = { status: res.status, message: 'Invalid URL parameter' };
+            break;
+        case 401:
+            result = { status: res.status, message: 'Unauthorized' };
+            break;
+        case 409:
+            result = { status: res.status, message: 'Alias exist' };
+            break;
+        case 415:
+            result = { status: res.status, message: 'Unsupported file format' };
+            break;
+        case 502:
+            result = { status: res.status, message: 'Writing file failed' };
+            break;
+        default:
+            result = { status: res.status };
+    }
+    return result;
+})
+.then(obj => console.log(obj))
+.catch(error => {
+    console.log(error);
+});

--- a/examples/pkg.put.js
+++ b/examples/pkg.put.js
@@ -45,4 +45,3 @@ fetch('http://localhost:4001/biz/pkg/fuzz/8.4.1', {
 .catch(error => {
     console.log(error);
 });
-

--- a/fixtures/sink-test.js
+++ b/fixtures/sink-test.js
@@ -152,7 +152,7 @@ class SinkTest {
                 return;
             }
 
-            if (this._state.has(filePath)) {
+            if (this._state.has(pathname)) {
                 resolve();
                 return;
             }

--- a/lib/handlers/alias.delete.js
+++ b/lib/handlers/alias.delete.js
@@ -13,6 +13,16 @@ class AliasDel {
         this._log = abslog(logger);
     }
 
+    async _exist (org, type, name, alias) {
+        try {
+            const path = Alias.buildPath(org, type, name, alias);
+            await this._sink.exist(path);
+            return true;
+        } catch (error) {
+            return false;
+        }
+    }
+
     async handler (req, org, type, name, alias) {
         try {
             validators.alias(alias);
@@ -20,14 +30,19 @@ class AliasDel {
             validators.type(type);
             validators.org(org);
         } catch (error) {
-            throw new HttpError(400, 'Bad request');
+            throw new HttpError.NotFound();
+        }
+
+        const exist = await this._exist(org, type, name, alias);
+        if (!exist) {
+            throw new HttpError.NotFound();
         }
 
         try {
             const path = Alias.buildPath(org, type, name, alias);
             await this._sink.delete(path);
         } catch (error) {
-            return new HttpError(502, 'Bad gateway');
+            return new HttpError.BadGateway();
         }
 
         const outgoing = new HttpOutgoing();

--- a/lib/handlers/alias.post.js
+++ b/lib/handlers/alias.post.js
@@ -34,7 +34,7 @@ class AliasPost {
                     try {
                         validators.version(value);
                     } catch (error) {
-                        busboy.destroy(new HttpError(502, 'Bad gateway'));
+                        busboy.destroy(new HttpError.BadRequest());
                         return;
                     }
                     alias.version = value;
@@ -51,7 +51,7 @@ class AliasPost {
                     );
                 } catch (error) {
                     // TODO: Will this trigger error or is it too late to do this in the finish event??????????
-                    busboy.destroy(new HttpError(502, 'Bad gateway'));
+                    busboy.destroy(new HttpError.BadGateway());
                     return;
                 }
 
@@ -74,6 +74,16 @@ class AliasPost {
         });
     }
 
+    async _exist (org, type, name, alias) {
+        try {
+            const path = Alias.buildPath(org, type, name, alias);
+            await this._sink.exist(path);
+            return true;
+        } catch (error) {
+            return false;
+        }
+    }
+
     async handler (req, org, type, name, alias) {
         try {
             validators.alias(alias);
@@ -81,7 +91,12 @@ class AliasPost {
             validators.type(type);
             validators.org(org);
         } catch (error) {
-            throw new HttpError(400, 'Bad request');
+            throw new HttpError.NotFound();
+        }
+
+        const exist = await this._exist(org, type, name, alias);
+        if (!exist) {
+            throw new HttpError.NotFound();
         }
 
         const incoming = new HttpIncoming(req, {

--- a/lib/handlers/alias.put.js
+++ b/lib/handlers/alias.put.js
@@ -34,7 +34,7 @@ class AliasPut {
                     try {
                         validators.version(value);
                     } catch (error) {
-                        busboy.destroy(new HttpError(502, 'Bad gateway'));
+                        busboy.destroy(new HttpError.BadRequest());
                         return;
                     }
                     alias.version = value;
@@ -51,7 +51,7 @@ class AliasPut {
                     );
                 } catch (error) {
                     // TODO: Will this trigger error or is it too late to do this in the finish event??????????
-                    busboy.destroy(new HttpError(502, 'Bad gateway'));
+                    busboy.destroy(new HttpError.BadGateway());
                     return;
                 }
 
@@ -74,6 +74,16 @@ class AliasPut {
         });
     }
 
+    async _exist (org, type, name, alias) {
+        try {
+            const path = Alias.buildPath(org, type, name, alias);
+            await this._sink.exist(path);
+            return true;
+        } catch (error) {
+            return false;
+        }
+    }
+
     async handler (req, org, type, name, alias) {
         try {
             validators.alias(alias);
@@ -81,7 +91,12 @@ class AliasPut {
             validators.type(type);
             validators.org(org);
         } catch (error) {
-            throw new HttpError(400, 'Bad request');
+            throw new HttpError.BadRequest();
+        }
+
+        const exist = await this._exist(org, type, name, alias);
+        if (exist) {
+            throw new HttpError.Conflict();
         }
 
         const incoming = new HttpIncoming(req, {

--- a/test/integration/fastify.js
+++ b/test/integration/fastify.js
@@ -276,13 +276,22 @@ test('Alias POST', async t => {
 
     sink.set('/biz/pkg/fuzz/8.4.1/main/index.js', 'hello world');
 
-    const formData = new FormData();
-    formData.append('version', '8.4.1');
+    const initData = new FormData();
+    initData.append('version', '8.4.0');
+
+    await fetch(`${address}/biz/pkg/fuzz/v8`, {
+        method: 'PUT',
+        body: initData,
+        headers: initData.getHeaders(),
+    });
+
+    const updateData = new FormData();
+    updateData.append('version', '8.4.1');
 
     await fetch(`${address}/biz/pkg/fuzz/v8`, {
         method: 'POST',
-        body: formData,
-        headers: formData.getHeaders(),
+        body: updateData,
+        headers: updateData.getHeaders(),
     });
 
     const contents = sink.get('/biz/pkg/fuzz/8.alias.json');


### PR DESCRIPTION
This appends an exist check to all the methods which alters aliases. The following will now happen:

- If a given alias does **not** exist, a `PUT` will create the alias and result in a 303 HTTP status.
- If a given alias does exist, a `PUT` will error by responding with a 409 HTTP status.
- If a given alias does **not** exist, a `POST` will error by responding with a 404 HTTP status.
- If a given alias does exist, a `POST` will update the alias and result in a 303 HTTP status.
- If a given alias does **not** exist, a `DELETE` will error by responding with a 404 HTTP status.
- If a given alias does exist, a `DELETE` will remove the alias and result in a 204 HTTP status.

Do note: some HTTP statuses have changed from what it was previously. This might have to be compensated by in the client.