### PR TITLE
Expose the package upload log

### DIFF
--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -63,7 +63,7 @@ Form parameters:
 
 Status codes:
 
--   `201` if module is successfully uploaded
+-   `303` if module is successfully uploaded. `location` is root of module
 -   `400` if validation in URL parameters or form fields fails
 -   `401` if user is not authorized
 -   `409` if module already exist

--- a/examples/pkg.put.js
+++ b/examples/pkg.put.js
@@ -18,7 +18,7 @@ fetch('http://localhost:4001/biz/pkg/fuzz/8.4.1', {
 .then(res => {
     let result = {};
     switch (res.status) {
-        case 201:
+        case 200:
             result = res.json();
             break;
         case 400:

--- a/lib/classes/upload-log.js
+++ b/lib/classes/upload-log.js
@@ -1,16 +1,13 @@
 'use strict';
 
-const path = require('path');
 const Asset = require('./asset');
 const Meta = require('./meta');
-const { BASE_ASSETS, ROOT } = require('../utils/globals');
 
 class UploadLog {
     constructor({ version = '', name = '', org = '' } = {}) {
         this._version = version;
         this._name = name;
         this._org = org;
-
         this._files = [];
         this._meta = [];
     }
@@ -25,24 +22,6 @@ class UploadLog {
 
     get org() {
         return this._org;
-    }
-
-    // URL pathname to the asset
-    get pathname() {
-        return this.constructor.buildPathname(
-            this._org,
-            this._name,
-            this._version,
-        );
-    }
-
-    // File system path to the asset
-    get path() {
-        return this.constructor.buildPath(
-            this._org,
-            this._name,
-            this._version,
-        );
     }
 
     setAsset(asset) {
@@ -63,7 +42,6 @@ class UploadLog {
 
     toJSON() {
         return {
-            pathname: this.pathname,
             version: this.version,
             name: this.name,
             org: this.org,
@@ -74,26 +52,6 @@ class UploadLog {
 
     get [Symbol.toStringTag]() {
         return 'UploadLog';
-    }
-
-    static buildPathname(org = '', name = '', version = '') {
-        return path.join(
-            ROOT,
-            org,
-            BASE_ASSETS,
-            name,
-            `${version}.log.json`,
-        );
-    }
-
-    static buildPath(org = '', name = '', version = '') {
-        return path.join(
-            ROOT,
-            org,
-            BASE_ASSETS,
-            name,
-            `${version}.log.json`,
-        );
     }
 }
 module.exports = UploadLog;

--- a/lib/handlers/pkg.log.js
+++ b/lib/handlers/pkg.log.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const { validators } = require('@asset-pipe/common');
+const HttpError = require('http-errors');
+const abslog = require('abslog');
+const HttpOutgoing = require('../classes/http-outgoing');
+const paths = require('../utils/paths');
+
+class PkgLog {
+    constructor(sink, config = {}, logger) {
+        this._config = config;
+        this._sink = sink;
+        this._log = abslog(logger);
+    }
+
+    async handler (req, org, name, version) {
+        try {
+            validators.version(version);
+            validators.name(name);
+            validators.org(org);
+        } catch (error) {
+            throw new HttpError.NotFound();
+        }
+
+        const path = paths.pkgLog({ org, name, version });
+
+        try {
+            const outgoing = new HttpOutgoing();
+            outgoing.mimeType = 'application/json';
+
+            const stream = await this._sink.read(path);
+            outgoing.stream = stream;
+
+            return outgoing;
+        } catch (error) {
+            throw new HttpError.NotFound();
+        }
+    }
+}
+module.exports = PkgLog;

--- a/lib/handlers/pkg.put.js
+++ b/lib/handlers/pkg.put.js
@@ -10,9 +10,11 @@ const tar = require('tar');
 const HttpIncoming = require('../classes/http-incoming');
 const HttpOutgoing = require('../classes/http-outgoing');
 const UploadLog = require('../classes/upload-log');
+const pathnames = require('../utils/pathnames');
 const Asset = require('../classes/asset');
 const Meta = require('../classes/meta');
 const utils = require('../utils/utils');
+const paths = require('../utils/paths');
 
 class PkgPut {
     constructor(sink, config = {}, logger) {
@@ -110,18 +112,22 @@ class PkgPut {
                     })
                     return log;
                 }).then(async (log) => {
+                    const path = paths.pkgLog(log);
                     await utils.writeJSON(
                         this._sink,
-                        log.path,
+                        path,
                         log,
                         'application/json',
                     );
                     return log;
                 }).then((log) => {
+                    const pathname = pathnames.pkgLog(log);
+
                     const outgoing = new HttpOutgoing();
-                    outgoing.mimeType = 'application/json';
-                    outgoing.statusCode = 201;
-                    outgoing.body = log;
+                    outgoing.mimeType = 'text/plain';
+                    outgoing.statusCode = 303;
+                    outgoing.location = pathname;
+
                     resolve(outgoing);
                 }).catch(err => {
                     reject(err);
@@ -137,7 +143,7 @@ class PkgPut {
 
     async _exist (org, name, version) {
         try {
-            const path = UploadLog.buildPath(org, name, version);
+            const path = paths.pkgLog({ org, name, version });
             await this._sink.exist(path);
             return true;
         } catch (error) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -4,6 +4,7 @@ const AliasPost = require('./handlers/alias.post');
 const AliasPut = require('./handlers/alias.put');
 const AliasGet = require('./handlers/alias.get');
 const AliasDel = require('./handlers/alias.delete');
+const PkgLog = require('./handlers/pkg.log');
 const PkgGet = require('./handlers/pkg.get');
 const PkgPut = require('./handlers/pkg.put');
 const MapGet = require('./handlers/map.get');
@@ -20,6 +21,7 @@ module.exports.http = {
     AliasPut,
     AliasGet,
     AliasDel,
+    PkgLog,
     PkgGet,
     PkgPut,
     MapGet,

--- a/lib/sinks/fs.js
+++ b/lib/sinks/fs.js
@@ -50,8 +50,6 @@ class SinkFS {
                     resolve(stream);
                 },
             );
-
-            // TODO: Handle if stream never opens or errors, set a timeout which will reject with an error
         });
     }
 
@@ -64,25 +62,40 @@ class SinkFS {
                 return;
             }
 
-            let streamClosed = true;
+            const closeFd = fd => {
+                fs.close(fd, () => {
+                    // TODO: Log errors
+                });
+            }
 
-            const stream = fs.createReadStream(pathname, {
-                autoClose: true,
-                emitClose: true,
-            });
-
-            stream.on('open', () => {
-                streamClosed = false;
-                resolve(stream);
-            });
-
-            stream.on('error', error => {
-                if (streamClosed) {
+            fs.open(pathname, 'r', (error, fd) => {
+                if (error) {
                     reject(error);
-                }
-            });
+                    return;
+                };
 
-            // TODO: Handle if stream never opens or errors, set a timeout which will reject with an error
+                fs.fstat(fd, (err, stat) => {
+                    if (err) {
+                        closeFd(fd);
+                        reject(err);
+                        return;
+                    };
+
+                    if (!stat.isFile()) {
+                        closeFd(fd);
+                        reject(new Error(`Not a file - ${pathname}`));
+                        return;
+                    }
+
+                    const stream = fs.createReadStream(pathname, {
+                        autoClose: true,
+                        fd,
+                    });
+
+                    resolve(stream)
+                });
+
+            });
         });
     }
 
@@ -102,8 +115,6 @@ class SinkFS {
                 }
                 resolve();
             });
-
-            // TODO: Handle if stream never opens or errors, set a timeout which will reject with an error
         });
     }
 

--- a/lib/utils/pathnames.js
+++ b/lib/utils/pathnames.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const path = require('path');
+const { BASE_ASSETS, ROOT } = require('../utils/globals');
+
+const pkgLog = ({ org = '', name = '', version = '' } = {}) => {
+    return path.join(ROOT, org, BASE_ASSETS, name, version);
+}
+module.exports.pkgLog = pkgLog;

--- a/lib/utils/paths.js
+++ b/lib/utils/paths.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const path = require('path');
+const { BASE_ASSETS, ROOT } = require('../utils/globals');
+
+const pkgLog = ({ org = '', name = '', version = '' } = {}) => {
+    return path.join(ROOT, org, BASE_ASSETS, name, `${version}.log.json`);
+}
+module.exports.pkgLog = pkgLog;

--- a/services/fastify.js
+++ b/services/fastify.js
@@ -40,6 +40,7 @@ class FastifyService {
         this._aliasDel = new http.AliasDel(this.sink, {}, logger);
         this._aliasGet = new http.AliasGet(this.sink, {}, logger);
         this._aliasPut = new http.AliasPut(this.sink, {}, logger);
+        this._pkgLog = new http.PkgLog(this.sink, {}, logger);
         this._pkgGet = new http.PkgGet(this.sink, {}, logger);
         this._pkgPut = new http.PkgPut(this.sink, {}, logger);
         this._mapGet = new http.MapGet(this.sink, {}, logger);
@@ -50,6 +51,23 @@ class FastifyService {
         //
         // Packages
         //
+
+        // curl -X GET http://localhost:4001/biz/pkg/fuzz/8.4.1
+
+        this.app.get(
+            `/:org/${prop.base_pkg}/:name/:version`, async (request, reply) => {
+                const outgoing = await this._pkgLog.handler(
+                    request.req,
+                    request.params.org,
+                    request.params.name,
+                    request.params.version,
+                );
+
+                reply.type(outgoing.mimeType);
+                reply.code(outgoing.statusCode);
+                reply.send(outgoing.stream);
+            },
+        );
 
         // curl -X GET http://localhost:4001/biz/pkg/fuzz/8.4.1/main/index.js
 
@@ -84,7 +102,7 @@ class FastifyService {
 
                 reply.type(outgoing.mimeType);
                 reply.code(outgoing.statusCode);
-                reply.send(outgoing.body);
+                reply.redirect(outgoing.location);
             },
         );
 

--- a/test/integration/fastify.js
+++ b/test/integration/fastify.js
@@ -42,7 +42,7 @@ test('Packages PUT - all files extracted, files accessible after upload', async 
         headers: formData.getHeaders(),
     });
 
-    t.equals(res.status, 201, 'server PUT should respond with 201 ok');
+    t.equals(res.status, 200, 'server PUT should respond with 200 ok');
 
     const file1 = await fetch(
         `${address}/foo/pkg/bar/1.1.1/main/index.js`,
@@ -99,7 +99,7 @@ test('Packages PUT - all files extracted, correct response received', async t =>
     });
     const obj = await res.json();
 
-    t.equals(res.status, 201, 'server should respond with 201 ok');
+    t.equals(res.status, 200, 'server should respond with 200 ok');
 
     t.equal(
         obj.files[0].pathname,


### PR DESCRIPTION
This exposes the upload log of a package on the root of a package `/:org/pkg/:name/:version`. It will return the following object:

```js
{
  version: '8.4.1',
  name: 'fuzz',
  org: 'biz',
  files: [
    {
      mimeType: 'application/javascript',
      pathname: '/biz/pkg/fuzz/8.4.1/main/index.js',
      type: 'file',
      size: 75208
    },
    ... snip ...
  ],
  meta: []
}
```

It also changes the HTTP status on `PUT` for the package from a 201 to a 303 which redirects to the upload log instead of returning it as a part of the body. When creating or updating a alias on a package these will now also redirect to this destination.

This raises one question though; 

Currently `/:org/pkg/:name/:version` will return this log file but I am not sure if that is the best location to expose this log file on. If we look at similar systems a package has a defined entry point. In many cases its defined on `main` or `module` in package.json:

```json
{
  "name": "fuzz",
  "version": "2.0.0",
  "main": "dist/index.js"
}
```
In similar systems whats defined for `main` or `module` is what is served on root of the package (where we now serve the upload log). The advantage of this is that one can point a script tag to the root of the package.

Should we do the same? And if so; what entry point do we serve the upload log on?