### PR TITLE
Revert "Pin dependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,15 +27,15 @@
     "validate-npm-package-name": "^3.0.0"
   },
   "devDependencies": {
-    "eslint": "6.6.0",
-    "eslint-config-airbnb-base": "14.0.0",
-    "eslint-config-prettier": "6.5.0",
-    "eslint-plugin-import": "2.18.2",
-    "eslint-plugin-prettier": "3.1.1",
-    "form-data": "3.0.0",
-    "mkdirp": "0.5.1",
-    "node-fetch": "2.6.0",
-    "prettier": "1.18.2",
-    "tap": "14.9.2"
+    "eslint": "^6.6.0",
+    "eslint-config-airbnb-base": "^14.0.0",
+    "eslint-config-prettier": "^6.5.0",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-prettier": "^3.1.1",
+    "form-data": "^3.0.0",
+    "mkdirp": "^0.5.1",
+    "node-fetch": "^2.6.0",
+    "prettier": "^1.18.2",
+    "tap": "^14.9.1"
   }
 }


### PR DESCRIPTION
We shouldn't pin dependencies, renovate got merged without using our finn preset: https://github.com/asset-pipe/core/commit/37316cd2c0a9328b64e906d382fca3c9eb938af9